### PR TITLE
Add SABAYON_WAIT env var

### DIFF
--- a/app.json
+++ b/app.json
@@ -16,7 +16,7 @@
     "HEROKU_TOKEN": {
       "description": "An heroku access token allowed to write config vars and SSL certificates on ACME_APP_NAME"
     },
-    "SABAYON_WAIT": {
+    "RESTART_WAIT_TIME": {
       "description": "Seconds to wait for ACME_APP_NAME to restart before completing verification. Long restarts will lead to H12 errors for your app but this may be useful to adjust when using preboot.",
       "value": "20"
     }

--- a/app.json
+++ b/app.json
@@ -15,6 +15,10 @@
     },
     "HEROKU_TOKEN": {
       "description": "An heroku access token allowed to write config vars and SSL certificates on ACME_APP_NAME"
+    },
+    "SABAYON_WAIT": {
+      "description": "Seconds to wait for ACME_APP_NAME to restart before completing verification. Long restarts will lead to H12 errors for your app but this may be useful to adjust when using preboot.",
+      "value": "20"
     }
   },
   "addons": ["scheduler"],

--- a/cmd/sabayon/main.go
+++ b/cmd/sabayon/main.go
@@ -25,6 +25,9 @@ func main() {
 	var token = os.Getenv("HEROKU_TOKEN")
 	var appName = os.Getenv("ACME_APP_NAME")
 	wait, _ := strconv.Atoi(os.Getenv("SABAYON_WAIT"))
+	if wait == 0 {
+		wait = 20
+	}
 
 	herokuClient := heroku.NewClient(nil, token)
 	certificates, err := herokuClient.GetSSLCertificates(appName)

--- a/cmd/sabayon/main.go
+++ b/cmd/sabayon/main.go
@@ -24,7 +24,7 @@ func main() {
 	var email = os.Getenv("ACME_EMAIL")
 	var token = os.Getenv("HEROKU_TOKEN")
 	var appName = os.Getenv("ACME_APP_NAME")
-	wait, _ := strconv.Atoi(os.Getenv("SABAYON_WAIT"))
+	wait, _ := strconv.Atoi(os.Getenv("RESTART_WAIT_TIME"))
 	if wait == 0 {
 		wait = 20
 	}

--- a/cmd/sabayon/main.go
+++ b/cmd/sabayon/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"log"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -23,6 +24,7 @@ func main() {
 	var email = os.Getenv("ACME_EMAIL")
 	var token = os.Getenv("HEROKU_TOKEN")
 	var appName = os.Getenv("ACME_APP_NAME")
+	wait, _ := strconv.Atoi(os.Getenv("SABAYON_WAIT"))
 
 	herokuClient := heroku.NewClient(nil, token)
 	certificates, err := herokuClient.GetSSLCertificates(appName)
@@ -73,7 +75,7 @@ func main() {
 			}
 
 			// Wait for a few seconds so the app can restart
-			time.Sleep(20 * time.Second)
+			time.Sleep(time.Duration(wait) * time.Second)
 
 			ce.ComChan <- "validate"
 		case r := <-ce.CertChan:


### PR DESCRIPTION
Adds an env var, `SABAYON_WAIT`, to set the number of seconds that sabayon waits for `ACME_APP_NAME` to restart. The default is `20`
