### PR TITLE
[ci skip] Add error handling to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,12 +72,14 @@ Add a `bin/start` file to your app:
       end
     end
 
-    `mkdir -p dist/.well-known/acme-challenge`
+    result = `mkdir -p dist/.well-known/acme-challenge`
+    raise result unless $?.success?
     data.each do |e|
-      `echo #{e[:key]} > dist/.well-known/acme-challenge/#{e[:token]}`
+      result = `echo #{e[:key]} > dist/.well-known/acme-challenge/#{e[:token]}`
+      raise result unless $?.success?
     end
 
-    `bin/boot`
+    exec("bin/boot")
 
 Make that file executable:
 


### PR DESCRIPTION
Check for failed shell commands, also use `exec` instead of backticks when running bin/boot so that the process output will take over the current process instead of being run silently in the background.
